### PR TITLE
fix reconnect for Mac

### DIFF
--- a/src/xbwd/client/WebsocketClient.cpp
+++ b/src/xbwd/client/WebsocketClient.cpp
@@ -148,6 +148,8 @@ WebsocketClient::connect()
             ripple::jv("what", e.what()),
             ripple::jv("ip", ep_.address()),
             ripple::jv("port", ep_.port()));
+        boost::system::error_code ecc;
+        stream_.close(ecc);
         std::weak_ptr<WebsocketClient> wptr = shared_from_this();
         timer_.expires_after(CONNECT_TIMEOUT);
         timer_.async_wait([wptr](boost::system::error_code const& ec) {


### PR DESCRIPTION
close the socket to clean the state when failed to connect. 