### PR TITLE
Fix compilation errors on windows - 'lt' cannot be implicitly capture…

### DIFF
--- a/src/xbwd/federator/Federator.cpp
+++ b/src/xbwd/federator/Federator.cpp
@@ -647,7 +647,7 @@ Federator::mainLoop()
     auto const lt = lt_event;
     {
         std::unique_lock l{loopMutexes_[lt]};
-        loopCvs_[lt].wait(l, [this] { return !loopLocked_[lt]; });
+        loopCvs_[lt].wait(l, [this, lt] { return !loopLocked_[lt]; });
     }
 
     std::vector<FederatorEvent> localEvents;
@@ -684,7 +684,7 @@ Federator::txnSubmitLoop()
     auto const lt = lt_txnSubmit;
     {
         std::unique_lock l{loopMutexes_[lt]};
-        loopCvs_[lt].wait(l, [this] { return !loopLocked_[lt]; });
+        loopCvs_[lt].wait(l, [this, lt] { return !loopLocked_[lt]; });
     }
 
     std::vector<ripple::STXChainAttestationBatch> localTxns;


### PR DESCRIPTION
…d because no default capture mode has been specified