### PR TITLE
Fix build against boost 1.80

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 build
 .nih_c
 .vs
+
+# Qt creator files
+CMakeLists.txt.user

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,3 @@
 build
 .nih_c
 .vs
-
-# Qt creator files
-CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,7 @@
 cmake_minimum_required (VERSION 3.11)
 project (xbridge_witnessd)
 
-set(CONAN_PATHS_1 ${CMAKE_BINARY_DIR}/conan_paths.cmake)
-set(CONAN_PATHS_2 ${CMAKE_BINARY_DIR}/conan-dependencies/conan_paths.cmake)
-
-if(EXISTS "${CONAN_PATHS_1}")
-    include(${CONAN_PATHS_1})
-elseif(EXISTS "${CONAN_PATHS_2}")
-    include(${CONAN_PATHS_2})
-else()
-    message(FATAL_ERROR  " conan_paths.cmake not found")
-endif()
+include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
@@ -165,3 +156,8 @@ if (has_parent)
   set_target_properties (xbridge_witnessd PROPERTIES EXCLUDE_FROM_ALL ON)
   set_target_properties (xbridge_witnessd PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD ON)
 endif ()
+
+#fix for MAC
+get_target_property(FMT_INC_DIRS fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
+list (GET FMT_INC_DIRS 0 FMT_INC_DIR)
+target_include_directories(xbridge_witnessd BEFORE PRIVATE ${FMT_INC_DIR})

--- a/src/xbwd/app/Config.cpp
+++ b/src/xbwd/app/Config.cpp
@@ -113,6 +113,9 @@ ChainConfig::ChainConfig(Json::Value const& jv)
     {
         txnSubmit.emplace(jv["TxnSubmit"]);
     }
+
+    if (jv.isMember("IgnoreSignerList"))
+        ignoreSignerList = jv["IgnoreSignerList"].asBool();
 }
 
 Config::Config(Json::Value const& jv)

--- a/src/xbwd/app/Config.h
+++ b/src/xbwd/app/Config.h
@@ -54,6 +54,7 @@ struct ChainConfig
     beast::IP::Endpoint chainIp;
     ripple::AccountID rewardAccount;
     std::optional<TxnSubmit> txnSubmit;
+    bool ignoreSignerList = false;
     explicit ChainConfig(Json::Value const& jv);
 };
 

--- a/src/xbwd/app/main.cpp
+++ b/src/xbwd/app/main.cpp
@@ -102,7 +102,8 @@ main(int argc, char** argv)
 
     try
     {
-        std::unique_ptr<xbwd::config::Config> config = [&]() -> auto {
+        std::unique_ptr<xbwd::config::Config> config = [&]() -> auto
+        {
             auto const configFile = [&]() -> std::string {
                 if (vm.count("config"))
                     return vm["config"].as<std::string>();
@@ -118,7 +119,8 @@ main(int argc, char** argv)
             if (!Json::Reader().parse(f, jv))
                 throw std::runtime_error("config file contains invalid json");
             return std::make_unique<xbwd::config::Config>(jv);
-        }();
+        }
+        ();
 
         if (vm.count("json"))
         {

--- a/src/xbwd/client/ChainListener.h
+++ b/src/xbwd/client/ChainListener.h
@@ -108,6 +108,11 @@ private:
     void
     processMessage(Json::Value const& msg) EXCLUDES(m_);
 
+    void
+    processAccountInfo(Json::Value const& msg) EXCLUDES(m_);
+    void
+    processSignerListSet(Json::Value const& msg) EXCLUDES(m_);
+
     template <class E>
     void
     pushEvent(E&& e) REQUIRES(m_);

--- a/src/xbwd/client/ChainListener.h
+++ b/src/xbwd/client/ChainListener.h
@@ -18,6 +18,7 @@
 */
 //==============================================================================
 
+#include <xbwd/basics/ChainTypes.h>
 #include <xbwd/basics/ThreadSaftyAnalysis.h>
 
 #include <ripple/beast/net/IPEndpoint.h>
@@ -39,11 +40,10 @@ class WebsocketClient;
 
 class ChainListener : public std::enable_shared_from_this<ChainListener>
 {
-public:
-    enum class IsMainchain { no, yes };
-
 private:
-    bool const isMainchain_;  // TODO change to isLockingChain?
+    const ChainType chainType_;
+    const std::string chainName_;
+
     ripple::STXChainBridge const bridge_;
     std::string witnessAccountStr_;
     std::weak_ptr<Federator> federator_;
@@ -58,7 +58,7 @@ private:
 
 public:
     ChainListener(
-        IsMainchain isMainchain,
+        ChainType chainType,
         ripple::STXChainBridge const sidechain,
         std::optional<ripple::AccountID> submitAccountOpt,
         std::weak_ptr<Federator>&& federator,
@@ -101,9 +101,6 @@ private:
 
     void
     onConnect();
-
-    std::string const&
-    chainName() const;
 
     void
     processMessage(Json::Value const& msg) EXCLUDES(m_);

--- a/src/xbwd/client/ChainListener.h
+++ b/src/xbwd/client/ChainListener.h
@@ -42,7 +42,6 @@ class ChainListener : public std::enable_shared_from_this<ChainListener>
 {
 private:
     const ChainType chainType_;
-    const std::string chainName_;
 
     ripple::STXChainBridge const bridge_;
     std::string witnessAccountStr_;
@@ -109,13 +108,7 @@ private:
     processAccountInfo(Json::Value const& msg) noexcept;
 
     void
-    processAccountInfoHlp(Json::Value const& msg);
-
-    void
     processSignerListSet(Json::Value const& msg) noexcept;
-
-    void
-    processSignerListSetHlp(Json::Value const& msg);
 
     template <class E>
     void

--- a/src/xbwd/client/ChainListener.h
+++ b/src/xbwd/client/ChainListener.h
@@ -106,9 +106,16 @@ private:
     processMessage(Json::Value const& msg) EXCLUDES(m_);
 
     void
-    processAccountInfo(Json::Value const& msg) EXCLUDES(m_);
+    processAccountInfo(Json::Value const& msg) noexcept;
+
     void
-    processSignerListSet(Json::Value const& msg) EXCLUDES(m_);
+    processAccountInfoHlp(Json::Value const& msg);
+
+    void
+    processSignerListSet(Json::Value const& msg) noexcept;
+
+    void
+    processSignerListSetHlp(Json::Value const& msg);
 
     template <class E>
     void

--- a/src/xbwd/federator/Federator.cpp
+++ b/src/xbwd/federator/Federator.cpp
@@ -595,8 +595,8 @@ Federator::onEvent(event::NewLedger const& e)
 void
 Federator::onEvent(event::XChainSignerListSet const& e)
 {
-    static const auto federatorAcc = calcAccountID(signingPK_);
-    static const auto encFederatorAcc = ripple::toBase58(federatorAcc);
+    const auto federatorAcc = calcAccountID(signingPK_);
+    const auto encFederatorAcc = ripple::toBase58(federatorAcc);
 
     auto& inSignList(inSignerList_[e.chainType_]);
     const auto ignoreSignerList(chains_[e.chainType_].ignoreSignerList_);
@@ -619,8 +619,7 @@ Federator::onEvent(event::XChainSignerListSet const& e)
         ripple::jv("ChainType", to_string(e.chainType_)),
         ripple::jv("inSignList", static_cast<int>(inSignList)),
         ripple::jv("ignoreSignerList", ignoreSignerList));
-
-}  // Federator::onEvent(event::XChainSignerListSet const& e)
+}
 
 void
 Federator::pushAttOnSubmitTxn(

--- a/src/xbwd/federator/Federator.cpp
+++ b/src/xbwd/federator/Federator.cpp
@@ -646,15 +646,12 @@ Federator::pushAttOnSubmitTxn(
     }
     else
     {
-        {
-            std::lock_guard tl{txnsMutex_};
-            curClaimAtts_[chainType].clear();
-            curCreateAtts_[chainType].clear();
-        }
+        curClaimAtts_[chainType].clear();
+        curCreateAtts_[chainType].clear();
 
         JLOGV(
             j_.info(),
-            "pushAttOnSubmitTxn, not in signer list, atestations dropped",
+            "not in signer list, atestations dropped",
             ripple::jv("ChainType", to_string(chainType)));
     }
 
@@ -663,7 +660,7 @@ Federator::pushAttOnSubmitTxn(
         std::lock_guard l(cvMutexes_[lt_event]);
         cvs_[lt_event].notify_one();
     }
-}  // Federator::pushAttOnSubmitTxn
+}
 
 void
 Federator::pushAtt(

--- a/src/xbwd/federator/Federator.cpp
+++ b/src/xbwd/federator/Federator.cpp
@@ -73,14 +73,14 @@ make_Federator(
 
     std::shared_ptr<ChainListener> mainchainListener =
         std::make_shared<ChainListener>(
-            ChainListener::IsMainchain::yes,
+            ChainType::locking,
             config.bridge,
             getSubmitAccount(ChainType::locking),
             r,
             j);
     std::shared_ptr<ChainListener> sidechainListener =
         std::make_shared<ChainListener>(
-            ChainListener::IsMainchain::no,
+            ChainType::issuing,
             config.bridge,
             getSubmitAccount(ChainType::issuing),
             r,

--- a/src/xbwd/federator/Federator.h
+++ b/src/xbwd/federator/Federator.h
@@ -72,6 +72,8 @@ struct Submission
 
 class Federator : public std::enable_shared_from_this<Federator>
 {
+    enum class IsInSignerList: int {iis_not_init = -1, iis_false = 0, iis_true};
+
     enum LoopTypes { lt_event, lt_txnSubmit, lt_last };
     std::array<std::thread, lt_last> threads_;
     bool running_ = false;
@@ -85,6 +87,7 @@ class Federator : public std::enable_shared_from_this<Federator>
         std::shared_ptr<ChainListener> listener_;
         ripple::AccountID rewardAccount_;
         std::optional<config::TxnSubmit> txnSubmit_;
+        bool ignoreSignerList_ = false;
 
         explicit Chain(config::ChainConfig const& config);
     };
@@ -102,6 +105,9 @@ class Federator : public std::enable_shared_from_this<Federator>
     ripple::KeyType const keyType_;
     ripple::PublicKey const signingPK_;
     ripple::SecretKey const signingSK_;
+
+    ChainArray<IsInSignerList>  inSignerList_ =
+        ChainArray<IsInSignerList>(IsInSignerList::iis_not_init, IsInSignerList::iis_not_init);
 
     // Use a condition variable to prevent busy waiting when the queue is
     // empty
@@ -199,6 +205,9 @@ private:
 
     void
     onEvent(event::XChainAttestsResult const& e);
+
+    void
+    onEvent(event::XChainSignerListSet const& e);
 
     void
     pushAtt(

--- a/src/xbwd/federator/Federator.h
+++ b/src/xbwd/federator/Federator.h
@@ -72,7 +72,7 @@ struct Submission
 
 class Federator : public std::enable_shared_from_this<Federator>
 {
-    enum class IsInSignerList: int {iis_not_init = -1, iis_false = 0, iis_true};
+    enum class KeySignerListStatus : int { unknown = -1, absent = 0, present };
 
     enum LoopTypes { lt_event, lt_txnSubmit, lt_last };
     std::array<std::thread, lt_last> threads_;
@@ -106,8 +106,9 @@ class Federator : public std::enable_shared_from_this<Federator>
     ripple::PublicKey const signingPK_;
     ripple::SecretKey const signingSK_;
 
-    ChainArray<IsInSignerList>  inSignerList_ =
-        ChainArray<IsInSignerList>(IsInSignerList::iis_not_init, IsInSignerList::iis_not_init);
+    ChainArray<KeySignerListStatus> inSignerList_{
+        KeySignerListStatus::unknown,
+        KeySignerListStatus::unknown};
 
     // Use a condition variable to prevent busy waiting when the queue is
     // empty

--- a/src/xbwd/federator/FederatorEvents.cpp
+++ b/src/xbwd/federator/FederatorEvents.cpp
@@ -118,6 +118,19 @@ NewLedger::toJson() const
     return result;
 }
 
+Json::Value
+XChainSignerListSet::toJson() const
+{
+    Json::Value result{Json::objectValue};
+    result["eventType"] = "XChainSignerListSet";
+    result["account"] = toBase58(account_);
+    auto& jAcc = (result["entries"] = Json::arrayValue);
+    for (auto const& acc : entries_)
+        jAcc.append(toBase58(acc));
+
+    return result;
+}
+
 }  // namespace event
 
 Json::Value

--- a/src/xbwd/federator/FederatorEvents.h
+++ b/src/xbwd/federator/FederatorEvents.h
@@ -122,10 +122,9 @@ struct NewLedger
     toJson() const;
 };
 
-
 // Signer list changed on chain account
 struct XChainSignerListSet
-{    
+{
     ChainType chainType_ = ChainType::locking;
     ripple::AccountID account_;
     std::vector<ripple::AccountID> entries_;

--- a/src/xbwd/federator/FederatorEvents.h
+++ b/src/xbwd/federator/FederatorEvents.h
@@ -121,6 +121,19 @@ struct NewLedger
     Json::Value
     toJson() const;
 };
+
+
+// Signer list changed on chain account
+struct XChainSignerListSet
+{    
+    ChainType chainType_ = ChainType::locking;
+    ripple::AccountID account_;
+    std::vector<ripple::AccountID> entries_;
+
+    Json::Value
+    toJson() const;
+};
+
 }  // namespace event
 
 using FederatorEvent = std::variant<
@@ -129,7 +142,8 @@ using FederatorEvent = std::variant<
     event::HeartbeatTimer,
     event::XChainTransferResult,
     event::XChainAttestsResult,
-    event::NewLedger>;
+    event::NewLedger,
+    event::XChainSignerListSet>;
 
 Json::Value
 toJson(FederatorEvent const& event);


### PR DESCRIPTION
## High Level Overview of Change
Fixes to make build more reliable

### Context of Change

1) CmakeLists.txt:4 – added additional path to search for conan_paths.cmake.  On my system it located at `${CMAKE_BINARY_DIR}/conan-dependencies` not at` ${CMAKE_BINARY_DIR}/`

2)CmakeLists.txt:41 – add the same boost macros-es as used in  RIPPLED.
  `BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT` – most important for build.

Since boost 1.7x  there are 2 realization of STRAND execution strategy 
OLD: https://www.boost.org/doc/libs/1_80_0/doc/html/boost_asio/reference/io_context__strand.html
NEW: https://www.boost.org/doc/libs/1_80_0/doc/html/boost_asio/reference/strand.html 

Also there are 2 realization of polymorphic executor class
OLD: https://www.boost.org/doc/libs/1_80_0/doc/html/boost_asio/reference/executor.html 
NEW: https://www.boost.org/doc/libs/1_80_0/doc/html/boost_asio/reference/any_io_executor.html 

Both strands and both executors were created for the same reason, but they are not interchangeable. And their interface has some differences.  In RIPPLED codebase they used all 4 of them – `strand`, `io_context_strand`, `executor` and `io_any_executor` in different mixes. Which may lead to conflicts in the future.  But for now Boost introduced   `BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT` – which just create typedef and `any_io_executor` became old `executor`.  

Boost info about executors - https://www.boost.org/doc/libs/1_80_0/doc/html/boost_asio/std_executors.html 
