### PR TITLE
RXI-411 witness server log configuration

### DIFF
--- a/src/xbwd/app/App.cpp
+++ b/src/xbwd/app/App.cpp
@@ -97,6 +97,15 @@ App::setup()
                 signalStop();
         });
 
+    if (!config_->logFile.empty())
+    {
+        if (!logs_.open(config_->logFile))
+            std::cerr << "Can't open log file " << config_->logFile
+                      << std::endl;
+    }
+    // Optionally turn off logging to console.
+    logs_.silent(config_->logSilent);
+
     {
         std::vector<ripple::Port> const ports = [&] {
             auto const& endpoint = config_->rpcEndpoint;

--- a/src/xbwd/app/Config.cpp
+++ b/src/xbwd/app/Config.cpp
@@ -126,8 +126,11 @@ Config::Config(Json::Value const& jv)
                      rpc::fromJson<ripple::Seed>(jv, "SigningKeySeed"))
                      .second}
     , bridge{rpc::fromJson<ripple::STXChainBridge>(jv, "XChainBridge")}
-    , adminConfig{
-          jv.isMember("Admin") ? AdminConfig::make(jv["Admin"]) : std::nullopt}
+    , adminConfig{jv.isMember("Admin") ? AdminConfig::make(jv["Admin"]) : std::nullopt}
+    , logFile(jv.isMember("LogFile") ? jv["LogFile"].asString() : std::string())
+    , logLevel(
+          jv.isMember("LogLevel") ? jv["LogLevel"].asString() : std::string())
+    , logSilent(jv.isMember("LogSilent") ? jv["LogSilent"].asBool() : false)
 {
 }
 

--- a/src/xbwd/app/Config.h
+++ b/src/xbwd/app/Config.h
@@ -69,6 +69,10 @@ public:
     ripple::STXChainBridge bridge;
     std::optional<AdminConfig> adminConfig;
 
+    std::string logFile;
+    std::string logLevel;
+    bool logSilent;
+
     explicit Config(Json::Value const& jv);
 };
 

--- a/src/xbwd/app/main.cpp
+++ b/src/xbwd/app/main.cpp
@@ -26,6 +26,18 @@
 #include <Windows.h>
 #endif
 
+static const std::unordered_map<std::string, beast::severities::Severity>
+    g_severityMap{
+        {"All", beast::severities::kAll},
+        {"Trace", beast::severities::kTrace},
+        {"Debug", beast::severities::kDebug},
+        {"Info", beast::severities::kInfo},
+        {"Warning", beast::severities::kWarning},
+        {"Error", beast::severities::kError},
+        {"Fatal", beast::severities::kFatal},
+        {"Disabled", beast::severities::kDisabled},
+        {"None", beast::severities::kNone}};
+
 void
 printHelp(const boost::program_options::options_description& desc)
 {
@@ -102,7 +114,8 @@ main(int argc, char** argv)
 
     try
     {
-        std::unique_ptr<xbwd::config::Config> config = [&]() -> auto {
+        std::unique_ptr<xbwd::config::Config> config = [&]() -> auto
+        {
             auto const configFile = [&]() -> std::string {
                 if (vm.count("config"))
                     return vm["config"].as<std::string>();
@@ -118,7 +131,8 @@ main(int argc, char** argv)
             if (!Json::Reader().parse(f, jv))
                 throw std::runtime_error("config file contains invalid json");
             return std::make_unique<xbwd::config::Config>(jv);
-        }();
+        }
+        ();
 
         if (vm.count("json"))
         {
@@ -157,6 +171,12 @@ main(int argc, char** argv)
                 return kFatal;
             else if (vm.count("verbose"))
                 return kTrace;
+            else if (!config->logLevel.empty())
+            {
+                const auto i = g_severityMap.find(config->logLevel);
+                if (i != g_severityMap.end())
+                    return i->second;
+            }
             return kInfo;
         }();
 


### PR DESCRIPTION
New options to configuration:
"LogFile": "/home/user/.local/.rippled/conf_local/witness0/wit0.log"   - if empty, no output to file
"LogLevel":   -  one of next string values ["All", "Trace", "Debug", "Info", "Warning",  "Error", "Fatal", "Disabled","None"]    
"LogSilent": false  -   on true disable console output (only to file)