### PR TITLE
RXI-716 Fix Ledger TTL checks

### DIFF
--- a/src/xbwd/client/ChainListener.cpp
+++ b/src/xbwd/client/ChainListener.cpp
@@ -1382,6 +1382,12 @@ ChainListener::processTx(Json::Value const& v) const
     }
 }
 
+std::uint32_t
+ChainListener::getProcessedLedger() const
+{
+    return ledgerProcessedDoor_;
+}
+
 void
 ChainListener::processAccountTx(Json::Value const& msg)
 {

--- a/src/xbwd/client/ChainListener.h
+++ b/src/xbwd/client/ChainListener.h
@@ -29,6 +29,7 @@
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/address.hpp>
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -100,8 +101,8 @@ private:
     // last ledger requested for new tx
     unsigned ledgerReqMax_ = 0;
     // last ledger that was processed for Door account (in case of errors /
-    // disconnects)
-    unsigned ledgerProcessedDoor_ = 0;
+    // disconnects). Will be requested from the other thread.
+    std::atomic_uint ledgerProcessedDoor_ = 0;
     // last ledger that was processed for Signing account (in case of errors /
     // disconnects)
     unsigned ledgerProcessedSign_ = 0;
@@ -160,6 +161,9 @@ public:
      */
     void
     processTx(Json::Value const& v) const;
+
+    std::uint32_t
+    getProcessedLedger() const;
 
 private:
     void


### PR DESCRIPTION
NewLedger event can be out of sync with  processed transactions, cause it came from subscription. TTL check should be done against the last processed ledger(processed transactions), not the last closed one.  