### PR TITLE
Save last processed ledger for issuing side

### DIFF
--- a/src/xbwd/client/ChainListener.h
+++ b/src/xbwd/client/ChainListener.h
@@ -62,12 +62,16 @@ struct HistoryProcessor
     // Ledger that divide transactions on historical and new
     unsigned startupLedger_ = 0;
 
-    // requesting ledgers in batch and check transactions after every batch
+    // Requesting ledgers in batch and check transactions after every batch
     // request
     unsigned const requestLedgerBatch_ = 100;
     unsigned toRequestLedger_ = 0;
 
+    // Minimal ledger validated by rippled. Retrieved from server_info
     unsigned minValidatedLedger_ = 0;
+
+    // History processed ledger
+    std::atomic_uint ledgerProcessed_ = 0;
 
     void
     clear();
@@ -79,7 +83,7 @@ private:
     ChainType const chainType_;
 
     ripple::STXChainBridge const bridge_;
-    std::string const witnessAccountStr_;
+    std::string const submittingAccountStr_;
     std::weak_ptr<Federator> const federator_;
     std::optional<ripple::AccountID> const signingAccount_;
     beast::Journal j_;
@@ -105,7 +109,7 @@ private:
     std::atomic_uint ledgerProcessedDoor_ = 0;
     // last ledger that was processed for Signing account (in case of errors /
     // disconnects)
-    unsigned ledgerProcessedSign_ = 0;
+    unsigned ledgerProcessedSubmit_ = 0;
     // To determine ledger boundary acros consecutive requests for given
     // account.
     std::int32_t prevLedgerIndex_ = 0;
@@ -164,6 +168,9 @@ public:
 
     std::uint32_t
     getProcessedLedger() const;
+
+    std::uint32_t
+    getHistoryProcessedLedger() const;
 
 private:
     void

--- a/src/xbwd/federator/Federator.h
+++ b/src/xbwd/federator/Federator.h
@@ -103,6 +103,9 @@ struct Submission
         ripple::XRPAmount const& fee,
         beast::Journal j) const = 0;
 
+    virtual bool
+    checkAttestation(event::XChainAttestsResult const& e) const = 0;
+
 protected:
     Submission(
         std::uint32_t lastLedgerSeq,
@@ -172,6 +175,9 @@ struct SubmissionClaim : public Submission
         config::TxnSubmit const& txn,
         ripple::XRPAmount const& fee,
         beast::Journal j) const override;
+
+    virtual bool
+    checkAttestation(event::XChainAttestsResult const& e) const override;
 };
 
 struct SubmissionCreateAccount : public Submission
@@ -202,6 +208,9 @@ struct SubmissionCreateAccount : public Submission
         config::TxnSubmit const& txn,
         ripple::XRPAmount const& fee,
         beast::Journal j) const override;
+
+    virtual bool
+    checkAttestation(event::XChainAttestsResult const& e) const override;
 };
 
 struct SignerListInfo
@@ -485,7 +494,7 @@ private:
         bool isCreateAccount);  // TODO add bridge
 
     void
-    sendDBAttests(ChainType ct);
+    readDBAttests(ChainType ct);
 
     friend std::shared_ptr<Federator>
     make_Federator(

--- a/src/xbwd/federator/Federator.h
+++ b/src/xbwd/federator/Federator.h
@@ -319,7 +319,6 @@ class Federator : public std::enable_shared_from_this<Federator>
         ripple::uint256 dbTxnHash_;
         std::uint32_t dbLedgerSqn_{0u};
         bool historyDone_{false};
-        bool oldTxExpired_{false};
         std::int32_t rpcOrder_{std::numeric_limits<std::int32_t>::min()};
         std::unordered_set<AttestedHistoryTx, ripple::hardened_hash<>>
             attestedTx_;


### PR DESCRIPTION
Normally issuing side doesn't have transactions that require attestation so it will not save "last attested tx" to the db. On the next session(restart) issuing listener will process all the transactions down to the xbridge transaction. It can take a long time. This patch save last fully processed ledger. So on the next restart issuing  listener will check ledgers only down to saved.
Removed oldTxExpired_ logic. Seems like it is no longer needed as we pulling closed ledgers only. 
