### PR TITLE
Separate syncing stuff by source chain

### DIFF
--- a/src/xbwd/app/DBInit.cpp
+++ b/src/xbwd/app/DBInit.cpp
@@ -12,10 +12,11 @@ xChainDBName()
     return r;
 }
 
+// Use the source that produce the event to get the table name
 std::string const&
-xChainTableName(ChainDir dir)
+xChainTableName(ChainType src)
 {
-    if (dir == ChainDir::lockingToIssuing)
+    if (src == ChainType::locking)
     {
         static std::string const r{"XChainTxnLockingToIssuing"};
         return r;
@@ -25,9 +26,9 @@ xChainTableName(ChainDir dir)
 }
 
 std::string const&
-xChainCreateAccountTableName(ChainDir dir)
+xChainCreateAccountTableName(ChainType src)
 {
-    if (dir == ChainDir::lockingToIssuing)
+    if (src == ChainType::locking)
     {
         static std::string const r{"XChainTxnCreateAccountLocking"};
         return r;
@@ -105,7 +106,7 @@ xChainDBInit()
                 LedgerSeq         BIGINT UNSIGNED);
         )sql";
 
-        for (auto cd : {ChainDir::lockingToIssuing, ChainDir::issuingToLocking})
+        for (auto cd : {ChainType::locking, ChainType::issuing})
         {
             r.push_back(fmt::format(
                 tblFmtStr, fmt::arg("table_name", xChainTableName(cd))));

--- a/src/xbwd/app/DBInit.h
+++ b/src/xbwd/app/DBInit.h
@@ -17,10 +17,10 @@ std::string const&
 xChainDBName();
 
 std::string const&
-xChainTableName(ChainDir dir);
+xChainTableName(ChainType chain);
 
 std::string const&
-xChainCreateAccountTableName(ChainDir dir);
+xChainCreateAccountTableName(ChainType chain);
 
 std::vector<std::string> const&
 xChainDBPragma();

--- a/src/xbwd/basics/ChainTypes.h
+++ b/src/xbwd/basics/ChainTypes.h
@@ -10,7 +10,6 @@
 namespace xbwd {
 
 using ChainType = ripple::STXChainBridge::ChainType;
-enum class ChainDir { issuingToLocking, lockingToIssuing };
 
 inline std::string
 to_string(ChainType ct)
@@ -21,18 +20,6 @@ to_string(ChainType ct)
         return r;
     }
     static std::string r{"issuing"};
-    return r;
-}
-
-inline std::string
-to_string(ChainDir cd)
-{
-    if (cd == ChainDir::lockingToIssuing)
-    {
-        static std::string r{"lockingToIssuing"};
-        return r;
-    }
-    static std::string r{"issuingToLocking"};
     return r;
 }
 

--- a/src/xbwd/client/WebsocketClient.cpp
+++ b/src/xbwd/client/WebsocketClient.cpp
@@ -177,7 +177,7 @@ WebsocketClient::send(
     JLOGV(
         j_.trace(),
         "WebsocketClient::send",
-        jv("chain_name", chain),
+        jv("chainType", chain),
         jv("msg", params));
     try
     {

--- a/src/xbwd/federator/FederatorEvents.cpp
+++ b/src/xbwd/federator/FederatorEvents.cpp
@@ -19,6 +19,8 @@
 
 #include <xbwd/federator/FederatorEvents.h>
 
+#include <ripple/protocol/jss.h>
+
 #include <fmt/core.h>
 
 #include <string_view>
@@ -41,6 +43,7 @@ Json::Value
 XChainCommitDetected::toJson() const
 {
     Json::Value result{Json::objectValue};
+    result["chainType"] = to_string(chainType_);
     result["eventType"] = "XChainCommitDetected";
     result["src"] = toBase58(src_);
     if (otherChainDst_)
@@ -59,6 +62,7 @@ Json::Value
 XChainAccountCreateCommitDetected::toJson() const
 {
     Json::Value result{Json::objectValue};
+    result["chainType"] = to_string(chainType_);
     result["eventType"] = "XChainAccountCreateCommitDetected";
     result["src"] = toBase58(src_);
     result["otherChainDst"] = toBase58(otherChainDst_);
@@ -77,6 +81,7 @@ Json::Value
 HeartbeatTimer::toJson() const
 {
     Json::Value result{Json::objectValue};
+    result["chainType"] = to_string(chainType_);
     result["eventType"] = "HeartbeatTimer";
     return result;
 }
@@ -86,14 +91,17 @@ XChainTransferResult::toJson() const
 {
     Json::Value result{Json::objectValue};
     result["eventType"] = "XChainTransferResult";
-    result["dir"] = to_string(dir_);
+    result["chainType"] = to_string(chainType_);
     result["dst"] = toBase58(dst_);
     if (deliveredAmt_)
         result["deliveredAmt"] =
             deliveredAmt_->getJson(ripple::JsonOptions::none);
     result["claimID"] = to_hex(claimID_);
     result["txnHash"] = to_string(txnHash_);
-    result["ter"] = transHuman(ter_);
+    std::string token, text;
+    transResultInfo(ter_, token, text);
+    result[ripple::jss::engine_result] = token;
+    result["ter"] = text;
     if (rpcOrder_)
         result["rpcOrder"] = *rpcOrder_;
     return result;
@@ -107,7 +115,10 @@ XChainAttestsResult::toJson() const
     result["chainType"] = to_string(chainType_);
     result["accountSequence"] = accountSqn_;
     result["txnHash"] = to_string(txnHash_);
-    result["ter"] = transHuman(ter_);
+    std::string token, text;
+    transResultInfo(ter_, token, text);
+    result[ripple::jss::engine_result] = token;
+    result["ter"] = text;
 
     result["isHistory"] = isHistory_;
     result["type"] = static_cast<int>(type_);
@@ -144,6 +155,7 @@ Json::Value
 XChainSignerListSet::toJson() const
 {
     Json::Value result{Json::objectValue};
+    result["chainType"] = to_string(chainType_);
     result["eventType"] = "XChainSignerListSet";
     result["masterDoorID"] = masterDoorID_.isNonZero()
         ? ripple::toBase58(masterDoorID_)
@@ -159,6 +171,7 @@ Json::Value
 XChainSetRegularKey::toJson() const
 {
     Json::Value result{Json::objectValue};
+    result["chainType"] = to_string(chainType_);
     result["eventType"] = "XChainSetRegularKey";
     result["masterDoorID"] = masterDoorID_.isNonZero()
         ? ripple::toBase58(masterDoorID_)
@@ -174,6 +187,7 @@ Json::Value
 XChainAccountSet::toJson() const
 {
     Json::Value result{Json::objectValue};
+    result["chainType"] = to_string(chainType_);
     result["eventType"] = "XChainAccountSet";
     result["masterDoorID"] = masterDoorID_.isNonZero()
         ? ripple::toBase58(masterDoorID_)

--- a/src/xbwd/federator/FederatorEvents.h
+++ b/src/xbwd/federator/FederatorEvents.h
@@ -37,7 +37,8 @@ namespace event {
 // A cross chain transfer was detected on this federator
 struct XChainCommitDetected
 {
-    ChainDir dir_;
+    // Source of the event
+    ChainType chainType_;
     // Src account on the src chain
     ripple::AccountID src_;
     ripple::STXChainBridge bridge_;
@@ -58,7 +59,8 @@ struct XChainCommitDetected
 // A cross chain account create was detected on this federator
 struct XChainAccountCreateCommitDetected
 {
-    ChainDir dir_;
+    // Source of the event
+    ChainType chainType_;
     // Src account on the src chain
     ripple::AccountID src_;
     ripple::STXChainBridge bridge_;
@@ -79,17 +81,15 @@ struct XChainAccountCreateCommitDetected
 
 struct HeartbeatTimer
 {
+    ChainType chainType_;
     Json::Value
     toJson() const;
 };
 
 struct XChainTransferResult
 {
-    // direction is the direction of the triggering transaction.
-    // I.e. A "mainToSide" transfer result is a transaction that
-    // happens on the sidechain (the triggering transaction happended on the
-    // mainchain)
-    ChainDir dir_;
+    // Source of the event
+    ChainType chainType_;
     ripple::AccountID dst_;
     std::optional<ripple::STAmount> deliveredAmt_;
     std::uint64_t claimID_;

--- a/src/xbwd/rpc/RPCHandler.cpp
+++ b/src/xbwd/rpc/RPCHandler.cpp
@@ -54,7 +54,7 @@ doSelectAll(
     App& app,
     Json::Value const& in,
     Json::Value& result,
-    ChainDir const chainDir)
+    ChainType const chain)
 
 {
     // TODO: Remove me
@@ -62,7 +62,7 @@ doSelectAll(
 
     result[ripple::jss::request] = in;
 
-    auto const& tblName = db_init::xChainTableName(chainDir);
+    auto const& tblName = db_init::xChainTableName(chain);
 
     {
         auto session = app.getXChainTxnDB().checkoutDb();
@@ -152,7 +152,7 @@ doSelectAll(
                 sendingAccount,
                 sendingAmount,
                 rewardAccount,
-                chainDir == ChainDir::lockingToIssuing,
+                chain == ChainType::locking,
                 claimID,
                 optDst);
         }
@@ -186,13 +186,13 @@ doSelectAll(
 void
 doSelectAllLocking(App& app, Json::Value const& in, Json::Value& result)
 {
-    return doSelectAll(app, in, result, ChainDir::lockingToIssuing);
+    return doSelectAll(app, in, result, ChainType::locking);
 }
 
 void
 doSelectAllIssuing(App& app, Json::Value const& in, Json::Value& result)
 {
-    return doSelectAll(app, in, result, ChainDir::issuingToLocking);
+    return doSelectAll(app, in, result, ChainType::issuing);
 }
 
 void
@@ -234,12 +234,11 @@ doWitness(App& app, Json::Value const& in, Json::Value& result)
     auto const& sendingAmount = *optAmt;
     auto const& claimID = *optClaimID;
 
-    ChainDir const chainDir = (*optDoor == optBridge->lockingChainDoor())
-        ? ChainDir::lockingToIssuing
-        : ChainDir::issuingToLocking;
+    ChainType const ct = (*optDoor == optBridge->lockingChainDoor())
+        ? ChainType::locking
+        : ChainType::issuing;
 
-    if (chainDir == ChainDir::issuingToLocking &&
-        *optDoor != optBridge->issuingChainDoor())
+    if (ct == ChainType::issuing && *optDoor != optBridge->issuingChainDoor())
     {
         // TODO: Write log message
         // put expected value in the error message?
@@ -250,7 +249,7 @@ doWitness(App& app, Json::Value const& in, Json::Value& result)
         return;
     }
 
-    auto const& tblName = db_init::xChainTableName(chainDir);
+    auto const& tblName = db_init::xChainTableName(ct);
 
     {
         auto session = app.getXChainTxnDB().checkoutDb();
@@ -335,7 +334,7 @@ doWitness(App& app, Json::Value const& in, Json::Value& result)
                 sendingAccount,
                 sendingAmount,
                 rewardAccount,
-                chainDir == ChainDir::lockingToIssuing,
+                ct == ChainType::locking,
                 claimID,
                 optDst};
 
@@ -417,11 +416,10 @@ doWitnessAccountCreate(App& app, Json::Value const& in, Json::Value& result)
     auto const& createCount = *optCreateCount;
     auto const& dst = *optDst;
 
-    ChainDir const chainDir = (*optDoor == optBridge->lockingChainDoor())
-        ? ChainDir::lockingToIssuing
-        : ChainDir::issuingToLocking;
-    if (chainDir == ChainDir::issuingToLocking &&
-        *optDoor != optBridge->issuingChainDoor())
+    ChainType const ct = (*optDoor == optBridge->lockingChainDoor())
+        ? ChainType::locking
+        : ChainType::issuing;
+    if (ct == ChainType::issuing && *optDoor != optBridge->issuingChainDoor())
     {
         // TODO: Write log message
         // put expected value in the error message?
@@ -432,7 +430,7 @@ doWitnessAccountCreate(App& app, Json::Value const& in, Json::Value& result)
         return;
     }
 
-    auto const& tblName = db_init::xChainCreateAccountTableName(chainDir);
+    auto const& tblName = db_init::xChainCreateAccountTableName(ct);
 
     std::vector<std::uint8_t> const encodedBridge = [&] {
         ripple::Serializer s;
@@ -512,7 +510,7 @@ doWitnessAccountCreate(App& app, Json::Value const& in, Json::Value& result)
                 sendingAmount,
                 rewardAmount,
                 rewardAccount,
-                chainDir == ChainDir::lockingToIssuing,
+                ct == ChainType::locking,
                 createCount,
                 dst};
 


### PR DESCRIPTION
Sync logic use mix of entities separated by sidechain. It is hard to say from just one look to the code to which side of sync logic belong something like `initSync_[ChainType::locking].dbTxnHash_`, cause some of them interact with  ChainType::locking side logic and some with ChainType::issuing.  Also there is `ChainDirection` entity which implicitly can switch from one side logic to other and need to be synchronized with  ChainType.  So one call to the function passing one side will lead to substitute calls some of them with the same side and some with opposite.
 
This PR remove implied use of sync entities and separate them by the chain that produce the entity. Any  cross-chain interaction explicitly put locally in the code, and functions called with one side will not call functions passing opposite side. 