### PR TITLE
Save last processed ledger

### DIFF
--- a/src/xbwd/client/ChainListener.cpp
+++ b/src/xbwd/client/ChainListener.cpp
@@ -1394,6 +1394,12 @@ ChainListener::getSubmitProcessedLedger() const
     return ledgerProcessedSubmit_;
 }
 
+std::uint32_t
+ChainListener::getHistoryProcessedLedger() const
+{
+    return hp_.ledgerProcessed_;
+}
+
 void
 ChainListener::processAccountTx(Json::Value const& msg)
 {
@@ -1562,6 +1568,10 @@ ChainListener::processAccountTxHlp(Json::Value const& msg)
 
         // if (!isMarker && isLast && isHistorical)
         //     history[ripple::jss::account_history_tx_first] = true;
+
+        if ((hp_.state_ != HistoryProcessor::FINISHED) &&
+            (prevLedgerIndex_ != ledgerIdx))
+            hp_.ledgerProcessed_ = prevLedgerIndex_;
 
         bool const lgrBdr = (hp_.state_ != HistoryProcessor::FINISHED)
             ? prevLedgerIndex_ != ledgerIdx

--- a/src/xbwd/client/ChainListener.h
+++ b/src/xbwd/client/ChainListener.h
@@ -70,6 +70,9 @@ struct HistoryProcessor
     // Minimal ledger validated by rippled. Retrieved from server_info
     unsigned minValidatedLedger_ = 0;
 
+    // History processed ledger
+    std::atomic_uint ledgerProcessed_ = 0;
+
     void
     clear();
 };
@@ -168,6 +171,9 @@ public:
 
     std::uint32_t
     getSubmitProcessedLedger() const;
+
+    std::uint32_t
+    getHistoryProcessedLedger() const;
 
 private:
     void

--- a/src/xbwd/client/RpcResultParse.cpp
+++ b/src/xbwd/client/RpcResultParse.cpp
@@ -25,6 +25,27 @@
 
 namespace xbwd {
 
+std::string
+to_string(XChainTxnType type)
+{
+    static std::array<
+        std::string,
+        static_cast<unsigned>(XChainTxnType::SetRegularKey) + 1> const TypeStr =
+        {"xChainCommit",
+         "xChainClaim",
+         "xChainAccountCreateCommit",
+#ifdef USE_BATCH_ATTESTATION
+         "xChainAddAttestationBatch",
+#endif
+         "xChainAddAccountCreateAttestation",
+         "xChainAddClaimAttestation",
+         "xChainCreateBridge",
+         "SignerListSet",
+         "AccountSet",
+         "SetRegularKey"};
+    return TypeStr[static_cast<unsigned>(type)];
+}
+
 namespace rpcResultParse {
 bool
 fieldMatchesStr(Json::Value const& val, char const* field, char const* toMatch)

--- a/src/xbwd/client/RpcResultParse.h
+++ b/src/xbwd/client/RpcResultParse.h
@@ -41,6 +41,9 @@ enum class XChainTxnType {
     SetRegularKey
 };
 
+std::string
+to_string(XChainTxnType type);
+
 namespace rpcResultParse {
 bool
 fieldMatchesStr(Json::Value const& val, char const* field, char const* toMatch);

--- a/src/xbwd/federator/Federator.h
+++ b/src/xbwd/federator/Federator.h
@@ -342,8 +342,7 @@ class Federator : public std::enable_shared_from_this<Federator>
         // previous session. Saved at the event chain side.
         ripple::uint256 dbTxnHash_;
 
-        // The latest ledger of the attestation sent in the previous session
-        // Saved at the attestation chain side.
+        // The latest ledger that was fully processed in the previous session.
         std::uint32_t dbLedgerSqn_{0u};
 
         // Request to stop processing history
@@ -534,6 +533,12 @@ private:
 
     void
     checkExpired(ChainType ct, std::uint32_t ledger);
+
+    void
+    checkProcessedLedger(ChainType ct);
+
+    void
+    saveProcessedLedger(ChainType ct, std::uint32_t ledger);
 };
 
 std::shared_ptr<Federator>


### PR DESCRIPTION
Normally  issuing(destination) side will not have transactions that require attestations. So it will not save any "last processed transaction" hash to the db. And on next restart it will not know when to stop, so it will process history down to bridge ledger.  This PR save last processed ledger and on check it against history processed ledger if it is time to stop processing history.  Also it allow to  remove saving ledger  to the db from the submitting loop.